### PR TITLE
Simplify Showtime Component, Accept Single Child

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,32 @@ const ComponentExample = () => {
 
 Pass `startWithTransition={true}` to automatically execute the `show` transition when the item initially mounts. It will be ignored if `show` is initially set to `false`.
 
+##### Additional performance consideration
+
+Since `Showtime` clones the child to attach its `ref`, it may be an expensive operation in some cases if the child component is substantially complicated. If so, provide a function that takes a `ref` and returns the child component instead, which may be more performant:
+
+```jsx
+import React, { useState } from "react";
+import { Showtime } from "react-showtime";
+
+const ComponentExample = () => {
+    const [show, setShow] = useState(true);
+
+    const toggle = () => setShow((current) => !current);
+
+    return (
+        <div>
+            <button onClick={toggle}>Toggle</button>
+            <Showtime show={show}>
+                {(ref) => <div ref={ref}>Oh hi</div>}
+            </Showtime>
+        </div>
+    );
+};
+```
+
+However, the direct child specification is recommended for most users.
+
 ### Transitions
 
 If you accept all defaults, you'll get a `slideFade` transition with a `250ms` duration, `16ms` delay, and `"ease"` easing:
@@ -289,6 +315,29 @@ const MultipleRefsExample = () => {
         <>
             <button onClick={toggle}>Toggle</button>
             {isMounted && <div ref={setRefs}>Hi there</div>}
+        </>
+    );
+};
+```
+
+Or if using the `Showtime` component:
+
+```jsx
+import React, { useRef } from "react";
+import { Showtime } from "react-showtime";
+
+const MultipleRefsExample = () => {
+    const myRef = useRef();
+    const [show, setShow] = useState(true);
+
+    const toggle = () => setShow((current) => !current);
+
+    return (
+        <>
+            <button onClick={toggle}>Toggle</button>
+            <Showtime show={show}>
+                <div ref={myRef}>Hi there</div>
+            </Showtime>
         </>
     );
 };

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Pass `{ startWithTransition: true }` to automatically execute the `show` transit
 
 #### Showtime component
 
-`Showtime` is a <a href="https://reactjs.org/docs/render-props.html">render prop component</a>. Its only child must be a function that accepts a `ref` parameter. Pass `ref` to your element or component.
+`Showtime` takes a single child component. It uses `useShowtime` under the hood, cloning the child and adding the `ref` to it.
 
 Toggle the `show` boolean prop to trigger show/hide.
 
@@ -97,7 +97,7 @@ const ComponentExample = () => {
         <div>
             <button onClick={toggle}>Toggle</button>
             <Showtime show={show}>
-                {(ref) => <div ref={ref}>Oh hi</div>}
+                <div>Oh hi</div>
             </Showtime>
         </div>
     );

--- a/example/src/examples/asymmetric.js
+++ b/example/src/examples/asymmetric.js
@@ -43,9 +43,7 @@ function Container() {
         }}
         hideTransition="fade"
       >
-        {(ref) => (
-          <RandomEmoji ref={ref} />
-        )}
+        <RandomEmoji />
       </Showtime>
       <Button 
         onClick={() => setShow((current) => !current)}

--- a/example/src/examples/asymmetric.js
+++ b/example/src/examples/asymmetric.js
@@ -18,7 +18,7 @@ function Container() {
   return (
     <>
       {isMounted && <RandomEmoji ref={ref} />}
-      <Button 
+      <Button
         onClick={isMounted ? hide : show}
         label={isMounted ? "Hide" : "Show"}
       />
@@ -35,7 +35,7 @@ function Container() {
 
   return (
     <>
-      <Showtime 
+      <Showtime
         show={show}
         showTransition={{
           transform: "translateY(400px) rotate(180deg)",
@@ -45,7 +45,7 @@ function Container() {
       >
         <RandomEmoji />
       </Showtime>
-      <Button 
+      <Button
         onClick={() => setShow((current) => !current)}
         label={show ? "Hide" : "Show"}
       />

--- a/example/src/examples/complex.js
+++ b/example/src/examples/complex.js
@@ -64,9 +64,7 @@ function Container() {
         hideDuration={300}
         hideEasing="cubic-bezier(0, -0.4, 0.54, -0.34)"
       >
-        {(ref) => (
-          <RandomEmoji ref={ref} />
-        )}
+        <RandomEmoji />
       </Showtime>
       <Button 
         onClick={() => setShow((current) => !current)}

--- a/example/src/examples/complex.js
+++ b/example/src/examples/complex.js
@@ -29,7 +29,7 @@ function Container() {
   return (
     <>
       {isMounted && <RandomEmoji ref={ref} />}
-      <Button 
+      <Button
         onClick={isMounted ? hide : show}
         label={isMounted ? "Hide" : "Show"}
       />
@@ -46,7 +46,7 @@ function Container() {
 
   return (
     <>
-      <Showtime 
+      <Showtime
         show={show}
         showTransition={{
           transform: "translateY(-200%)",
@@ -66,7 +66,7 @@ function Container() {
       >
         <RandomEmoji />
       </Showtime>
-      <Button 
+      <Button
         onClick={() => setShow((current) => !current)}
         label={show ? "Hide" : "Show"}
       />

--- a/example/src/examples/custom.js
+++ b/example/src/examples/custom.js
@@ -41,9 +41,7 @@ function Container() {
           opacity: 0,
         }}
       >
-        {(ref) => (
-          <RandomEmoji ref={ref} />
-        )}
+        <RandomEmoji />
       </Showtime>
       <Button 
         onClick={() => setShow((current) => !current)}

--- a/example/src/examples/custom.js
+++ b/example/src/examples/custom.js
@@ -17,7 +17,7 @@ function Container() {
   return (
     <>
       {isMounted && <RandomEmoji ref={ref} />}
-      <Button 
+      <Button
         onClick={isMounted ? hide : show}
         label={isMounted ? "Hide" : "Show"}
       />
@@ -34,7 +34,7 @@ function Container() {
 
   return (
     <>
-      <Showtime 
+      <Showtime
         show={show}
         transition={{
           transform: "translateY(400px) rotate(180deg)",
@@ -43,7 +43,7 @@ function Container() {
       >
         <RandomEmoji />
       </Showtime>
-      <Button 
+      <Button
         onClick={() => setShow((current) => !current)}
         label={show ? "Hide" : "Show"}
       />

--- a/example/src/examples/defaults.js
+++ b/example/src/examples/defaults.js
@@ -13,7 +13,7 @@ function Container() {
     <>
       {isMounted && <RandomEmoji ref={ref} />}
       <RandomEmoji />
-      <Button 
+      <Button
         onClick={isMounted ? hide : show}
         label={isMounted ? "Hide" : "Show"}
       />
@@ -34,7 +34,7 @@ function Container() {
         <RandomEmoji />
       </Showtime>
       <RandomEmoji />
-      <Button 
+      <Button
         onClick={() => setShow((current) => !current)}
         label={show ? "Hide" : "Show"}
       />

--- a/example/src/examples/defaults.js
+++ b/example/src/examples/defaults.js
@@ -31,9 +31,7 @@ function Container() {
   return (
     <>
       <Showtime show={show}>
-        {(ref) => (
-          <RandomEmoji ref={ref} />
-        )}
+        <RandomEmoji />
       </Showtime>
       <RandomEmoji />
       <Button 

--- a/example/src/examples/list.js
+++ b/example/src/examples/list.js
@@ -29,13 +29,13 @@ function Container() {
       {items.map(item => (
         <Item
           key={item}
-          onHidden={() => 
+          onHidden={() =>
             items.splice(items.indexOf(item), 1)
           }
         />
       ))}
-      <Button 
-        onClick={() => 
+      <Button
+        onClick={() =>
           setItems((current) => [Date.now(), ...current])
         }
         label="Add"

--- a/example/src/examples/list.js
+++ b/example/src/examples/list.js
@@ -17,9 +17,7 @@ function Item({onHidden, ...props}) {
       onHidden={onHidden}
       {...props}
     >
-      {(ref) => (
-        <RandomEmoji ref={ref} onClose={() => setShow(false)} />
-      )}
+      <RandomEmoji onClose={() => setShow(false)} />
     </Showtime>
   );
 }

--- a/example/src/examples/timing.js
+++ b/example/src/examples/timing.js
@@ -17,7 +17,7 @@ function Container() {
   return (
     <>
       {isMounted && <RandomEmoji ref={ref} />}
-      <Button 
+      <Button
         onClick={isMounted ? hide : show}
         label={isMounted ? "Hide" : "Show"}
       />
@@ -34,7 +34,7 @@ function Container() {
 
   return (
     <>
-      <Showtime 
+      <Showtime
         show={show}
         transition="scale"
         duration={600}
@@ -43,7 +43,7 @@ function Container() {
       >
         <RandomEmoji />
       </Showtime>
-      <Button 
+      <Button
         onClick={() => setShow((current) => !current)}
         label={show ? "Hide" : "Show"}
       />

--- a/example/src/examples/timing.js
+++ b/example/src/examples/timing.js
@@ -41,9 +41,7 @@ function Container() {
         delay={250}
         easing="linear"
       >
-        {(ref) => (
-          <RandomEmoji ref={ref} />
-        )}
+        <RandomEmoji />
       </Showtime>
       <Button 
         onClick={() => setShow((current) => !current)}

--- a/example/src/examples/transitions.js
+++ b/example/src/examples/transitions.js
@@ -46,9 +46,7 @@ function Container() {
   return (
     <>
       <Showtime show={show} transition="${name}">
-        {(ref) => (
-          <RandomEmoji ref={ref} />
-        )}
+        <RandomEmoji />
       </Showtime>
       ${hasSecondItem ? "<RandomEmoji />" : ""}
       <Button 

--- a/example/src/examples/transitions.js
+++ b/example/src/examples/transitions.js
@@ -25,7 +25,7 @@ function Container() {
     <>
       {isMounted && <RandomEmoji ref={ref} />}
       ${hasSecondItem ? "<RandomEmoji />" : ""}
-      <Button 
+      <Button
         onClick={isMounted ? hide : show}
         label={isMounted ? "Hide" : "Show"}
       />
@@ -49,7 +49,7 @@ function Container() {
         <RandomEmoji />
       </Showtime>
       ${hasSecondItem ? "<RandomEmoji />" : ""}
-      <Button 
+      <Button
         onClick={() => setShow((current) => !current)}
         label={show ? "Hide" : "Show"}
       />

--- a/src/Showtime.jsx
+++ b/src/Showtime.jsx
@@ -17,7 +17,7 @@ export default function Showtime({
     children,
     ...props
 }) {
-    const [ref, isMounted, show, hide, status] = useShowtime({
+    const [showtimeRef, isMounted, show, hide, status] = useShowtime({
         startHidden: !shouldShow,
         ...props,
     });
@@ -70,5 +70,27 @@ export default function Showtime({
         }
     }, [status, previousStatus, onHidden, onShowing]);
 
-    return isMounted ? cloneElement(Children.only(children), { ref }) : null;
+    // If child is a function like (ref) => <Child ref={ref} />
+    if (typeof children === "function") {
+        return isMounted ? children(showtimeRef) : null;
+    }
+
+    // Otherwise it is a component <Child />, to which ref must be attached
+    const child = Children.only(children);
+
+    return isMounted
+        ? cloneElement(child, {
+              ref(node) {
+                  showtimeRef.current = node;
+
+                  // Attach existing refs on child, if any
+                  const { ref } = child;
+                  if (ref?.hasOwnProperty("current")) {
+                      ref.current = node;
+                  } else if (typeof ref === "function") {
+                      ref(node);
+                  }
+              },
+          })
+        : null;
 }

--- a/src/Showtime.jsx
+++ b/src/Showtime.jsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from "react";
+import { Children, cloneElement, useRef, useEffect, useState } from "react";
 import useShowtime from "./useShowtime";
 import { STATUS } from "./constants";
 
@@ -70,5 +70,5 @@ export default function Showtime({
         }
     }, [status, previousStatus, onHidden, onShowing]);
 
-    return isMounted ? children(ref) : null;
+    return isMounted ? cloneElement(Children.only(children), { ref }) : null;
 }


### PR DESCRIPTION
## Overview

Previously the Showtime component took a function as a child, which took a ref and attached it to the wrapped component. That function is now moved to be inside the library, simplifying the client API.

The way the ref is attached to the child element is by cloning the element and attaching the ref to the clone. This may have some performance penalty, depending on the complexity of the component. This may also have other consequences, say if the client code is tracking that component otherwise (e.g. by using a ref of their own).

## Demo

Previously:

```jsx
<Showtime show={show}>
  {(ref) => <div ref={ref}>Oh hi</div>}
</Showtime>
```

Now:
```jsx
<Showtime show={show}>
  <div>Oh hi</div>
</Showtime>
```

## Notes

There is also a lint commit which was an artifact of my editor removing trailing spaces. If they are meaningful spaces, I can drop that commit to keep them in.

## Testing Instructions

I don't have a great sense of the edge cases and performance implications described above. Generally I prefer simplicity to performance, and think this will help ease adoption of the project. In my limited testing it seemed to work fine, but would appreciate those more familiar with this project run it through the ringer.

Not sure how best to test this. Just ensure that it still works correctly with the new API, I guess.