### PR TITLE
Allow GTM in content security policy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -19,8 +19,10 @@
   [headers.values]
     Content-Security-Policy = """
       default-src 'self';
+      connect-src 'self' https://www.google-analytics.com;
       font-src 'self' https://fonts.gstatic.com;
-      script-src 'self' 'unsafe-eval' 'unsafe-inline';
+      img-src 'self' https://www.google-analytics.com https://www.googletagmanager.com;
+      script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com;
       style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
       """
     X-Frame-Options = "DENY"


### PR DESCRIPTION
## Overview

Relax CSP to allow loading Google Analytics through Google Tag Manager.

Closes #25 

## Testing Instructions

- Verify that the [Netlify deploy](https://app.netlify.com/sites/react-showtime/deploys/5fc68a6aaedfa90007375709) was sucessful.
- Verify that the [deploy preview](https://deploy-preview-26--react-showtime.netlify.app/) loads without any CSP errors in the console.