### PR TITLE
Hotfix 2020-12-01

### DIFF
--- a/example/src/examples/defaults.js
+++ b/example/src/examples/defaults.js
@@ -1,7 +1,7 @@
 export const name = "Defaults";
 
 export const desc =
-    "Default transition (slideFade), duration (250ms), delay (0ms), and easing (ease).";
+    "Default transition (slideFade), duration (250ms), delay (16ms), and easing (ease).";
 
 export const hook = `
 // import { useShowtime } from "react-showtime";

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,8 +19,10 @@
   [headers.values]
     Content-Security-Policy = """
       default-src 'self';
+      connect-src 'self' https://www.google-analytics.com;
       font-src 'self' https://fonts.gstatic.com;
-      script-src 'self' 'unsafe-eval' 'unsafe-inline';
+      img-src 'self' https://www.google-analytics.com https://www.googletagmanager.com;
+      script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.google-analytics.com https://ssl.google-analytics.com https://www.googletagmanager.com;
       style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
       """
     X-Frame-Options = "DENY"


### PR DESCRIPTION
## Overview

Relax CSP to allow loading Google Analytics through Google Tag Manager. Increase delay in default description.

Closes #25 

## Testing Instructions

- Verify that the [Netlify deploy](https://app.netlify.com/sites/react-showtime/deploys/5fc7b73fbd83660007a7ddfa) was sucessful.
- Verify that the [deploy preview](https://deploy-preview-27--react-showtime.netlify.app/) loads without any CSP errors in the console.