### PR TITLE
Create hotfix PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/HOTFIX.md
+++ b/.github/PULL_REQUEST_TEMPLATE/HOTFIX.md
@@ -20,6 +20,7 @@ $ git flow hotfix publish YYYY-MM-DD
 - [ ] Finish and publish the hotfix branch:
     - When prompted, keep default commit messages
     - Use `-n` to skip tagging
+    - Use `-p` to push changes to the remote repository
 ```bash
-$ git flow hotfix finish -n
+$ git flow hotfix finish -n -p
 ```

--- a/.github/PULL_REQUEST_TEMPLATE/HOTFIX.md
+++ b/.github/PULL_REQUEST_TEMPLATE/HOTFIX.md
@@ -1,0 +1,25 @@
+---
+name: Hotfix YYYY-MM-DD
+about: When applying a hotfix for the example site
+title: Hotfix YYYY-MM-DD
+labels: hotfix
+assignees: ''
+
+---
+
+- [ ] Start a new hotfix branch:
+```bash
+$ git flow hotfix start YYYY-MM-DD
+```
+- [ ] Make commits to hotfix branch to address any issues that need to be resolved
+- [ ] Publish the hotfix branch:
+```bash
+$ git flow hotfix publish YYYY-MM-DD
+```
+- [ ] Create a PR for the hotfix branch, target it to `main`, have it reviewed, and confirm that all checks pass
+- [ ] Finish and publish the hotfix branch:
+    - When prompted, keep default commit messages
+    - Use `-n` to skip tagging
+```bash
+$ git flow hotfix finish -n
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "*"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -431,3 +431,5 @@ To get started:
 
 1.  `yarn start` here to watch for local changes to `react-showtime`,
 2.  `yarn start` in `example/` to watch for changes to the demo site and run a dev server.
+
+This project uses the [Git Flow](https://nvie.com/posts/a-successful-git-branching-model/) branching workflow. Usage of the [`gitflow-avh`](https://github.com/petervanderdoes/gitflow-avh) CLI tool is recommended for releases and hotfixes.


### PR DESCRIPTION
## Overview

Sets up a PR template to document the steps for creating a hotfix for the example site. The example site is not versioned with the library and will usually be released as part of regular library releases, but in cases like #27 it may be necessary to release a version of the site without creating a release for the library.

The hotfix instructions are a little looser than the release instructions. My intent is to strike a good balance between flexibility and having a simple checklist to follow.

## Testing Instructions

- Review and critique hotfix workflow.